### PR TITLE
Add OpenAI chatbot assistant section

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,51 @@
     </div>
   </section>
 
+  <!-- チャットボットセクション -->
+  <section class="chatbot" id="chatbot">
+    <div class="container">
+      <h2 class="section-title">AIチャットアシスタント</h2>
+      <div class="chatbot-content">
+        <div class="chatbot-info fade-in">
+          <h3 class="chatbot-subtitle">高速応答で業務の疑問を即解決</h3>
+          <p>OpenAIの最新APIを活用した高性能チャットボットです。業務アプリの企画、要件定義、運用に関するご相談をその場でサポートし、Sosinaの導入検討を後押しします。</p>
+          <ul class="chatbot-benefits">
+            <li><i class="fas fa-bolt"></i> GPT-4o miniによる高速レスポンス</li>
+            <li><i class="fas fa-shield-alt"></i> APIキーはブラウザ内でのみ保存・利用</li>
+            <li><i class="fas fa-language"></i> ビジネス日本語・英語の両方に対応</li>
+          </ul>
+        </div>
+        <div class="chatbot-panel fade-in">
+          <div class="chatbot-api-key" aria-live="polite">
+            <label for="openaiApiKey">OpenAI APIキー</label>
+            <div class="api-key-input-group">
+              <input type="password" id="openaiApiKey" placeholder="sk-..." autocomplete="off">
+              <button type="button" class="btn btn-secondary btn-compact" id="toggleApiKeyVisibility" aria-pressed="false" aria-label="APIキーの表示を切り替え">表示</button>
+              <button type="button" class="btn btn-primary btn-compact" id="saveApiKey">保存</button>
+            </div>
+            <p class="api-key-note">※ キーはこのブラウザのローカルに暗号化せず保存されます。共有端末では利用後に削除してください。</p>
+          </div>
+          <div class="chatbot-window" role="region" aria-live="polite" aria-label="チャットボットとの会話">
+            <div class="chatbot-messages" id="chatbotMessages">
+              <div class="chatbot-message assistant">
+                <div class="chatbot-bubble">こんにちは。株式会社SosinaのAIアシスタントです。業務アプリの活用方法や機能の相談など、お気軽にご質問ください。</div>
+              </div>
+            </div>
+            <div class="chatbot-status" id="chatbotStatus" role="status" aria-live="polite"></div>
+            <form id="chatForm" class="chatbot-form" novalidate>
+              <label for="chatInput" class="visually-hidden">メッセージを入力</label>
+              <textarea id="chatInput" rows="2" placeholder="例: 見積作成を自動化するワークフローを作りたい" required></textarea>
+              <div class="chatbot-actions">
+                <button type="button" class="btn btn-secondary btn-compact" id="clearChat">履歴をリセット</button>
+                <button type="submit" class="btn btn-primary btn-compact" id="sendChat">送信</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- お問い合わせセクション -->
   <section class="contact" id="contact">
     <div class="container">

--- a/script.js
+++ b/script.js
@@ -5,6 +5,15 @@ const nav = document.querySelector('.nav');
 const backToTopButton = document.querySelector('.back-to-top');
 const contactForm = document.getElementById('contactForm');
 const animationElements = document.querySelectorAll('.fade-in, .slide-in-left, .slide-in-right, .zoom-in');
+const chatbotForm = document.getElementById('chatForm');
+const chatInput = document.getElementById('chatInput');
+const chatMessages = document.getElementById('chatbotMessages');
+const chatStatus = document.getElementById('chatbotStatus');
+const sendChatButton = document.getElementById('sendChat');
+const clearChatButton = document.getElementById('clearChat');
+const apiKeyInput = document.getElementById('openaiApiKey');
+const saveApiKeyButton = document.getElementById('saveApiKey');
+const toggleApiKeyButton = document.getElementById('toggleApiKeyVisibility');
 
 // ========== ヘルパー関数 ==========
 
@@ -221,6 +230,306 @@ if (contactForm) {
   });
 }
 
+// ========== チャットボット機能 ==========
+if (chatbotForm && chatMessages) {
+  const OPENAI_STORAGE_KEY = 'sosina-openai-api-key';
+  const CHATBOT_SYSTEM_PROMPT = `You are the AI concierge for Sosina, a Japanese SaaS company that builds custom business web applications. Reply in polite Japanese unless the user explicitly requests another language. Keep answers concise (around 5 sentences) and focus on actionable advice that highlights Sosina's strengths such as rapid delivery, low monthly pricing, and workflow automation. Ask clarifying questions when requirements are ambiguous.`;
+  const INITIAL_ASSISTANT_MESSAGE = 'こんにちは。株式会社SosinaのAIアシスタントです。業務アプリの活用方法や機能の相談など、お気軽にご質問ください。';
+  const MAX_CHAT_HISTORY = 16;
+  const chatHistory = [{ role: 'system', content: CHATBOT_SYSTEM_PROMPT }];
+  const decoder = new TextDecoder('utf-8');
+  const sendButtonDefaultLabel = sendChatButton ? sendChatButton.textContent : '';
+
+  function trimChatHistory() {
+    if (chatHistory.length <= MAX_CHAT_HISTORY) return;
+    const systemMessage = chatHistory[0];
+    const recentMessages = chatHistory.slice(-1 * (MAX_CHAT_HISTORY - 1));
+    chatHistory.length = 0;
+    chatHistory.push(systemMessage, ...recentMessages);
+  }
+
+  function appendChatMessage(role, content, { persist = true } = {}) {
+    if (!chatMessages) return null;
+    const messageElement = document.createElement('div');
+    messageElement.className = `chatbot-message ${role}`;
+    const bubble = document.createElement('div');
+    bubble.className = 'chatbot-bubble';
+    bubble.textContent = content;
+    messageElement.appendChild(bubble);
+    chatMessages.appendChild(messageElement);
+    chatMessages.scrollTop = chatMessages.scrollHeight;
+
+    if (persist) {
+      chatHistory.push({ role, content });
+      trimChatHistory();
+    }
+
+    return bubble;
+  }
+
+  function updateChatStatus(message = '', type = 'info') {
+    if (!chatStatus) return;
+    chatStatus.textContent = message;
+    chatStatus.classList.remove('error', 'success');
+    if (type === 'error') {
+      chatStatus.classList.add('error');
+    } else if (type === 'success') {
+      chatStatus.classList.add('success');
+    }
+  }
+
+  function setLoadingState(isLoading) {
+    if (sendChatButton) {
+      sendChatButton.disabled = isLoading;
+      sendChatButton.textContent = isLoading ? '送信中…' : (sendButtonDefaultLabel || '送信');
+    }
+    if (chatInput) {
+      chatInput.disabled = isLoading;
+    }
+    if (clearChatButton) {
+      clearChatButton.disabled = isLoading;
+    }
+  }
+
+  function getStoredApiKey() {
+    try {
+      return localStorage.getItem(OPENAI_STORAGE_KEY) || '';
+    } catch (error) {
+      console.warn('APIキーの取得に失敗しました:', error);
+      return '';
+    }
+  }
+
+  function storeApiKey(keyValue) {
+    try {
+      if (!keyValue) {
+        localStorage.removeItem(OPENAI_STORAGE_KEY);
+      } else {
+        localStorage.setItem(OPENAI_STORAGE_KEY, keyValue);
+      }
+    } catch (error) {
+      console.warn('APIキーの保存に失敗しました:', error);
+    }
+  }
+
+  function resolveApiKey() {
+    const manualKey = (apiKeyInput && apiKeyInput.value.trim()) || '';
+    if (manualKey) return manualKey;
+    return getStoredApiKey();
+  }
+
+  async function streamChatCompletion(messages, apiKey, onDelta) {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages,
+        temperature: 0.3,
+        stream: true,
+        max_tokens: 600
+      })
+    });
+
+    if (!response.ok) {
+      let errorMessage = `OpenAI APIエラー: ${response.status}`;
+      try {
+        const errorPayload = await response.json();
+        if (errorPayload?.error?.message) {
+          errorMessage = `OpenAI APIエラー: ${errorPayload.error.message}`;
+        }
+      } catch (err) {
+        console.warn('エラーレスポンスの解析に失敗しました:', err);
+      }
+      throw new Error(errorMessage);
+    }
+
+    if (!response.body || !response.body.getReader) {
+      const fallback = await response.json();
+      const text = fallback?.choices?.[0]?.message?.content?.trim();
+      if (text) {
+        onDelta(text);
+        return text;
+      }
+      throw new Error('応答の取得に失敗しました。');
+    }
+
+    const reader = response.body.getReader();
+    let assistantText = '';
+    let buffer = '';
+    let doneReading = false;
+
+    while (!doneReading) {
+      const { value, done } = await reader.read();
+      doneReading = done;
+      buffer += decoder.decode(value || new Uint8Array(), { stream: !done });
+      const lines = buffer.split('\n');
+      if (!done) {
+        buffer = lines.pop() || '';
+      } else {
+        buffer = '';
+      }
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith('data:')) {
+          continue;
+        }
+
+        const data = trimmed.replace(/^data:\s*/, '');
+        if (data === '[DONE]') {
+          doneReading = true;
+          break;
+        }
+
+        try {
+          const parsed = JSON.parse(data);
+          const delta = parsed?.choices?.[0]?.delta?.content;
+          if (delta) {
+            assistantText += delta;
+            onDelta(assistantText);
+          }
+        } catch (error) {
+          console.warn('レスポンスチャンクの解析に失敗しました:', error);
+        }
+      }
+    }
+
+    if (!assistantText) {
+      throw new Error('応答の生成に失敗しました。');
+    }
+
+    return assistantText;
+  }
+
+  function resetChat() {
+    chatHistory.length = 0;
+    chatHistory.push({ role: 'system', content: CHATBOT_SYSTEM_PROMPT });
+    if (chatMessages) {
+      chatMessages.innerHTML = '';
+    }
+    appendChatMessage('assistant', INITIAL_ASSISTANT_MESSAGE);
+    if (chatInput) {
+      chatInput.value = '';
+    }
+  }
+
+  function initialiseChatbot() {
+    resetChat();
+    const storedKey = getStoredApiKey();
+    if (storedKey && apiKeyInput) {
+      apiKeyInput.value = storedKey;
+    }
+    updateChatStatus('OpenAI APIキーを入力してチャットを開始してください。');
+  }
+
+  async function handleChatSubmit(event) {
+    event.preventDefault();
+    if (!chatInput) return;
+
+    const userMessage = chatInput.value.trim();
+    if (!userMessage) {
+      updateChatStatus('メッセージを入力してください。', 'error');
+      chatInput.focus();
+      return;
+    }
+
+    const apiKey = resolveApiKey();
+    if (!apiKey) {
+      updateChatStatus('OpenAI APIキーを入力・保存してください。', 'error');
+      if (apiKeyInput) {
+        apiKeyInput.focus();
+      }
+      return;
+    }
+
+    appendChatMessage('user', userMessage);
+    const outgoingMessages = chatHistory.map(message => ({ ...message }));
+    const assistantBubble = appendChatMessage('assistant', '', { persist: false });
+
+    setLoadingState(true);
+    updateChatStatus('OpenAI APIと通信しています…');
+
+    try {
+      const assistantReply = await streamChatCompletion(outgoingMessages, apiKey, text => {
+        if (assistantBubble) {
+          assistantBubble.textContent = text;
+          chatMessages.scrollTop = chatMessages.scrollHeight;
+        }
+      });
+
+      const bubbleToUpdate = assistantBubble || appendChatMessage('assistant', '', { persist: false });
+      if (bubbleToUpdate) {
+        bubbleToUpdate.textContent = assistantReply;
+      }
+
+      chatHistory.push({ role: 'assistant', content: assistantReply });
+      trimChatHistory();
+      if (chatInput) {
+        chatInput.value = '';
+        chatInput.focus();
+      }
+      updateChatStatus('回答が完了しました。', 'success');
+    } catch (error) {
+      console.error('チャットボットの応答に失敗しました:', error);
+      const fallbackMessage = '申し訳ありません。応答の取得に失敗しました。APIキーとネットワーク状況をご確認ください。';
+      const errorBubble = assistantBubble || appendChatMessage('assistant', '', { persist: false });
+      if (errorBubble) {
+        errorBubble.textContent = fallbackMessage;
+      }
+      chatHistory.push({ role: 'assistant', content: fallbackMessage });
+      trimChatHistory();
+      updateChatStatus(error.message || 'エラーが発生しました。', 'error');
+    } finally {
+      setLoadingState(false);
+    }
+  }
+
+  initialiseChatbot();
+
+  chatbotForm.addEventListener('submit', handleChatSubmit);
+
+  if (chatInput) {
+    chatInput.addEventListener('keydown', event => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        chatbotForm.requestSubmit();
+      }
+    });
+  }
+
+  if (clearChatButton) {
+    clearChatButton.addEventListener('click', () => {
+      resetChat();
+      updateChatStatus('チャット履歴をリセットしました。', 'success');
+    });
+  }
+
+  if (saveApiKeyButton) {
+    saveApiKeyButton.addEventListener('click', () => {
+      const keyValue = (apiKeyInput && apiKeyInput.value.trim()) || '';
+      storeApiKey(keyValue);
+      if (keyValue) {
+        updateChatStatus('APIキーを保存しました。', 'success');
+      } else {
+        updateChatStatus('保存済みのAPIキーを削除しました。', 'success');
+      }
+    });
+  }
+
+  if (toggleApiKeyButton && apiKeyInput) {
+    toggleApiKeyButton.addEventListener('click', () => {
+      const isPassword = apiKeyInput.type === 'password';
+      apiKeyInput.type = isPassword ? 'text' : 'password';
+      toggleApiKeyButton.textContent = isPassword ? '非表示' : '表示';
+      toggleApiKeyButton.setAttribute('aria-pressed', String(isPassword));
+    });
+  }
+}
+
 // ========== エラーハンドリング ==========
 // グローバルエラーハンドラー
 window.addEventListener('error', function(e) {
@@ -233,7 +542,7 @@ document.querySelectorAll('img').forEach(img => {
   img.addEventListener('error', function() {
     this.style.display = 'none';
     console.warn(`画像の読み込みに失敗: ${this.src}`);
-    
+
     // ロゴ画像の場合、テキストで代替
     if (this.alt.includes('ロゴ')) {
       const textLogo = document.createElement('div');

--- a/styles.css
+++ b/styles.css
@@ -488,6 +488,199 @@ img {
   color: var(--primary-color);
 }
 
+/* ========== チャットボットセクション ========== */
+.chatbot {
+  padding: var(--spacing-3xl) 0;
+}
+
+.chatbot-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xl);
+}
+
+.chatbot-info {
+  flex: 1 1 320px;
+}
+
+.chatbot-subtitle {
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  margin-bottom: var(--spacing-sm);
+}
+
+.chatbot-benefits {
+  margin-top: var(--spacing-md);
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.chatbot-benefits li {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: var(--text-light);
+}
+
+.chatbot-benefits i {
+  color: var(--secondary-color);
+}
+
+.chatbot-panel {
+  flex: 1 1 420px;
+  background: linear-gradient(135deg, rgba(74, 107, 255, 0.1), rgba(52, 211, 153, 0.15));
+  border-radius: var(--border-radius);
+  padding: var(--spacing-lg);
+  box-shadow: var(--box-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.chatbot-api-key label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.api-key-input-group {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+}
+
+.api-key-input-group input {
+  flex: 1 1 200px;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--gray-200);
+  font-size: var(--font-size-md);
+}
+
+.api-key-input-group input:focus {
+  outline: 3px solid rgba(74, 107, 255, 0.25);
+  border-color: var(--primary-color);
+}
+
+.api-key-note {
+  font-size: var(--font-size-sm);
+  color: var(--text-lighter);
+  margin-top: 0.25rem;
+}
+
+.chatbot-window {
+  background-color: var(--white);
+  border-radius: var(--border-radius);
+  padding: var(--spacing-md);
+  box-shadow: var(--box-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  min-height: 420px;
+}
+
+.chatbot-messages {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding-right: 0.25rem;
+}
+
+.chatbot-message {
+  display: flex;
+  gap: var(--spacing-xs);
+}
+
+.chatbot-message.assistant {
+  justify-content: flex-start;
+}
+
+.chatbot-message.user {
+  justify-content: flex-end;
+}
+
+.chatbot-bubble {
+  max-width: 85%;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  background-color: var(--gray-100);
+  color: var(--text-dark);
+  box-shadow: var(--box-shadow);
+  white-space: pre-wrap;
+  line-height: 1.6;
+}
+
+.chatbot-message.assistant .chatbot-bubble {
+  background-color: var(--white);
+  border: 1px solid rgba(74, 107, 255, 0.15);
+}
+
+.chatbot-message.user .chatbot-bubble {
+  background: linear-gradient(135deg, var(--primary-color), var(--primary-dark));
+  color: var(--white);
+}
+
+.chatbot-status {
+  min-height: 1.2rem;
+  font-size: var(--font-size-sm);
+  color: var(--text-lighter);
+}
+
+.chatbot-status.error {
+  color: #ef4444;
+}
+
+.chatbot-status.success {
+  color: var(--secondary-color);
+}
+
+.chatbot-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.chatbot-form textarea {
+  resize: vertical;
+  min-height: 70px;
+  max-height: 200px;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-md);
+  font-family: var(--font-family);
+  line-height: 1.6;
+}
+
+.chatbot-form textarea:focus {
+  outline: 3px solid rgba(74, 107, 255, 0.25);
+  border-color: var(--primary-color);
+}
+
+.chatbot-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-xs);
+}
+
+.btn-compact {
+  padding: 0.5rem 0.9rem;
+  font-size: var(--font-size-sm);
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 /* ========== お問い合わせセクション ========== */
 .contact {
   padding: var(--spacing-3xl) 0;
@@ -721,7 +914,23 @@ img {
   .achievements-grid {
     grid-template-columns: 1fr;
   }
-  
+
+  .chatbot-panel {
+    padding: var(--spacing-md);
+  }
+
+  .chatbot-window {
+    min-height: 360px;
+  }
+
+  .chatbot-actions {
+    flex-direction: column;
+  }
+
+  .chatbot-actions .btn-compact {
+    width: 100%;
+  }
+
   /* ロゴを画面幅いっぱいに設定（ハンバーガーメニュー用のスペースを確保） */
   .logo {
     width: calc(100% - 60px);
@@ -746,7 +955,21 @@ img {
     --font-size-3xl: 1.5rem;
     --spacing-3xl: 3rem;
   }
-  
+
+  .api-key-input-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .api-key-input-group input,
+  .api-key-input-group .btn-compact {
+    width: 100%;
+  }
+
+  .chatbot-window {
+    min-height: 320px;
+  }
+
   .contact-form {
     padding: var(--spacing-md);
   }


### PR DESCRIPTION
## Summary
- add an AI chatbot section to the landing page with API key controls and messaging UI
- integrate OpenAI's chat completions API with streaming responses, history trimming, and key persistence
- style the chatbot experience to match the site and handle responsive layouts

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e4fff5ae008331a8016a575d2d1aad